### PR TITLE
Replace format A/B test with synonyms

### DIFF
--- a/app/views/shared/_search_box.html.erb
+++ b/app/views/shared/_search_box.html.erb
@@ -13,7 +13,7 @@
 
     <div class="form-group">
       <%= f.label :which_test, "A/B test being used", class: "form-label" %>
-      <%= f.select :which_test, { "Format Weighting" => "format_weighting", "None" => "none" }, {}, class: "form-control AB_select" %>
+      <%= f.select :which_test, { "Synonyms" => "synonyms", "None" => "none" }, {}, class: "form-control AB_select" %>
     </div>
 
     <div class="host-wrapper" id="host-wrapper">


### PR DESCRIPTION
The format weighting A/B test has ended, and we are investigating an A/B test of synonyms.

https://trello.com/c/9VF3Rw5V/451-test-synonyms-with-healthcheck-and-search-performance-explorer