### PR TITLE
Add a debug command to inspect elasticsearch explain plans

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'figaro'
 gem 'gds-api-adapters'
 gem 'govuk_admin_template'
 gem 'govuk_frontend_toolkit', git: "https://github.com/alphagov/govuk_frontend_toolkit_gem.git", submodules: true
-
+gem "rainbow"
 gem 'rest-client', '~> 2.0.2'
 
 # Use Capistrano for deployment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ DEPENDENCIES
   pry
   puma (~> 3.11)
   rails (~> 5.1.4)
+  rainbow
   rake
   rest-client (~> 2.0.2)
   rspec-rails

--- a/app/lib/explainotron.rb
+++ b/app/lib/explainotron.rb
@@ -1,0 +1,59 @@
+module Explainotron
+  def self.explain!(query, hostname: Plek.find('rummager'))
+    client = GdsApi::Rummager.new(hostname)
+
+    Results.new(
+      query,
+      client.search(
+        q: query,
+        debug: "explain,disable_best_bets,disable_popularity,disable_boosting",
+        count: 3
+      )["results"]
+    )
+  end
+
+  class Results
+    def initialize(query, results)
+      @results = results
+      @query = query
+    end
+
+    def report
+      results.each do |result|
+        title = result["title"]
+        description = result["description"]
+        puts Rainbow(title).yellow + " - #{description}"
+        puts ""
+        report_result(result["_explanation"])
+        puts ""
+      end
+    end
+
+  private
+
+    attr_reader :query, :results
+
+    def report_result(explain_output, indent: 0)
+      details = explain_output["details"]
+      value = explain_output["value"]
+      description = explain_output["description"]
+
+      description.gsub!(/[0-9.]+/) do |match|
+        Rainbow(match).cyan
+      end
+
+      description.gsub!(/(?<=:)(.*)(?= in)/) do |match|
+        Rainbow(match).green
+      end
+
+      spaces = ' ' * indent
+      puts spaces.to_s + Rainbow("[#{value}] ").magenta + description
+
+      if details
+        details.each do |detail|
+          report_result(detail, indent: indent + 2)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -1,0 +1,8 @@
+require 'gds_api/rummager'
+
+namespace :debug do
+  desc "Run the core of the search query with explain plans enabled and special boosting disabled"
+  task :explain, [:query] => :environment do |_, args|
+    Explainotron.explain!(args.query).report
+  end
+end


### PR DESCRIPTION
When investigating why a document scored higher/lower than anticipated, or why a result matched at all, the boosting is fairly easy to understand, but it's hard to see what the core of the search query is doing, particularly if synonyms are causing the query to be interpreted in a funny way. The explain plan sheds some light on this, but it's very long and confusing when the whole query is used.

This is a minimal rake task that disables all boosting and best bets, enables the explain plan, runs the query and then formats the explain plan in a readable way, highlighting which terms in the query matched the documents.

The next step would be to incorporate it into the rails app itself. I might have a stab at this at after christmas.

I initially implemented this in rummager here: https://github.com/alphagov/rummager/pull/1040 but @dwhenry  suggested this would be a better place for it.