### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/app/lib/explainotron.rb
+++ b/app/lib/explainotron.rb
@@ -1,5 +1,5 @@
 module Explainotron
-  def self.explain!(query, hostname: Plek.find('rummager'))
+  def self.explain!(query, hostname: Plek.find('search'))
     client = GdsApi::Rummager.new(hostname)
 
     Results.new(


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)