### PR TITLE
Add a Jenkinsfile to run tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,7 @@
+#!/usr/bin/env groovy
+
+library("govuk")
+
+node {
+  govuk.buildProject()
+}


### PR DESCRIPTION
- Previously, this repo ran tests on CircleCI. This hasn't worked for a
  while since the CircleCI webhook was disabled. Now Platform Health
  nominally manage it, standardize on Jenkins like the rest of the GOV.UK
  apps.