### PR TITLE
Remove usage of ActiveRecord

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,2 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
+class ApplicationRecord
 end


### PR DESCRIPTION
This application does not use ActiveRecord.

When deploying it to Heroku we see the error `NameError: uninitialized constant ActiveRecord`

This isn't used, so removing this is OK.