### PR TITLE
Remove call to ActiveRecord in Rails helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require "capybara/rspec"
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
+# ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
We are not using AR in this app, so we can comment out this call.