### PR TITLE
Replace govuk-lint with rubocop-govuk and scss-lint-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
  Metrics/BlockLength:
     Exclude:
       - "spec/**/*"

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+plugin_gems: ['scss_lint-govuk']

--- a/Gemfile
+++ b/Gemfile
@@ -47,11 +47,12 @@ group :development, :test do
   gem "byebug", platforms: %i(mri mingw x64_mingw)
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 2.17"
-  gem "govuk-lint"
   gem "json"
   gem "pry"
   gem "rake"
   gem "rspec-rails"
+  gem "rubocop-govuk"
+  gem "scss_lint-govuk"
   gem "selenium-webdriver"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,11 +101,6 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.0.1)
-      rubocop (~> 0.72)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.6.0)
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.3.1)
@@ -116,7 +111,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -155,7 +150,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
-    parallel (1.17.0)
+    parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     plek (2.1.1)
@@ -219,13 +214,17 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.75.0)
+    rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -246,9 +245,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -302,7 +298,6 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   figaro
   gds-api-adapters
-  govuk-lint
   govuk_admin_template
   govuk_frontend_toolkit!
   jbuilder (~> 2.5)
@@ -316,6 +311,7 @@ DEPENDENCIES
   rake
   rest-client (~> 2.0.2)
   rspec-rails
+  rubocop-govuk
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,10 +1,10 @@
 namespace :lint do
-  desc "Run govuk-lint on ruby files"
+  desc "Run rubocop on ruby files"
   task "ruby_lint" do
-    sh "bundle exec govuk-lint-ruby --format clang app config Gemfile lib spec"
+    sh "bundle exec rubocop  --format clang app Gemfile lib spec"
   end
-  desc "Run govuk-lint on the stylesheet"
+  desc "Run scss-lint on the stylesheet"
   task "css_lint" do
-    sh "bundle exec govuk-lint-sass app/assets/stylesheets"
+    sh "bundle exec scss-lint app/assets/stylesheets"
   end
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk