### PR TITLE
Add shingles + LTR AB Test

### DIFF
--- a/app/lib/searching.rb
+++ b/app/lib/searching.rb
@@ -60,10 +60,15 @@ class Searching
         q: params["search"]["search_term"],
         fields: FIELDS,
         count: count.to_s,
-        ab_tests: "#{params['search']['which_test']}:#{test}",
+        ab_tests: ab_tests(test),
         c: Time.now.getutc.to_s,
       },
       "Authorization" => ENV["#{host_name.upcase}_AUTH_TOKEN"],
     )
+  end
+
+  def ab_tests(variant)
+    tests = params['search']['which_test']
+    tests.split(",").map { |test| "#{test}:#{variant}" }.join(",")
   end
 end

--- a/app/views/shared/_search_box.html.erb
+++ b/app/views/shared/_search_box.html.erb
@@ -13,7 +13,12 @@
 
     <div class="form-group">
       <%= f.label :which_test, "A/B test being used", class: "form-label" %>
-      <%= f.select :which_test, { "Learning To Rank" => "relevance", "Shingles" => "shingles", "None" => "none" }, {}, class: "form-control AB_select" %>
+      <%= f.select :which_test, {
+        "Learning To Rank" => "relevance",
+        "Shingles" => "shingles",
+        "None" => "none",
+        "LTR + Shingles" => "shingles,relevance",
+      }, {}, class: "form-control AB_select" %>
     </div>
 
     <div class="host-wrapper" id="host-wrapper">

--- a/spec/features/searching_spec.rb
+++ b/spec/features/searching_spec.rb
@@ -25,4 +25,16 @@ RSpec.describe Searching do
       expect(large_search.count).to eql(1000)
     end
   end
+
+  describe "#ab_tests" do
+    it "handles a single AB test" do
+      search = described_class.new("search" => { "which_test" => "relevance,shingles" })
+      expect(search.ab_tests("B")).to eql("relevance:B,shingles:B")
+    end
+
+    it "handles multiple AB tests" do
+      search = described_class.new("search" => { "which_test" => "relevance" })
+      expect(search.ab_tests("B")).to eql("relevance:B")
+    end
+  end
 end


### PR DESCRIPTION
This permits us to use multiple ab test combinations in selections.

It'll always have all ab_tests = A on one side and = B on the other, which we might want to be able to configure in future. But this should suffice for now.

https://trello.com/c/HH7750rX/1286-shingles-for-further-analysis