### PR TITLE
New ab tests

### DIFF
--- a/app/views/result/index.html.erb
+++ b/app/views/result/index.html.erb
@@ -15,12 +15,10 @@
 
     <div class="heading">
       <% if @search.search_term? %>
-        <h1 class="head-text">You searched for</h1>
-        <h2 class="search-term"><%= @search.search_term %></h2>
+        <h1 class="head-text">You searched for '<%= @search.search_term %>'</h1>
       <% else %>
         <h1 class="head-text">You did not enter a search term</h1>
       <% end %>
-      <h2 class="results-text">These are your results</h2>
     </div>
 
   </div>

--- a/app/views/shared/_search_box.html.erb
+++ b/app/views/shared/_search_box.html.erb
@@ -14,10 +14,10 @@
     <div class="form-group">
       <%= f.label :which_test, "A/B test being used", class: "form-label" %>
       <%= f.select :which_test, {
-        "Learning To Rank" => "relevance",
+        "Learning To Rank" => "learning_to_rank",
         "Shingles" => "shingles",
         "None" => "none",
-        "LTR + Shingles" => "shingles,relevance",
+        "Shingles without LTR" => "shingles_without_ltr",
       }, {}, class: "form-control AB_select" %>
     </div>
 


### PR DESCRIPTION
relevance:disable is now used over relevance:B to toggle the LTR feature.

Since we can't use letters (A,B) anymore, I've changed how AB test combinations are selected.

This should give us a bit more freedom to make comparisons between combinations of ab tests.

https://trello.com/c/1EjO05Dj/1333