### PR TITLE
Restore asset compress after Rails 6 upgrade

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,9 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  # Compress JS using a preprocessor.
+  config.assets.js_compressor = :uglifier
+
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 


### PR DESCRIPTION
## What

Changes to `production.rb` to restore asset compression to previous output.

## Why

* The upgrade to Rails 6 disabled JS compression because it now defaults to using webpack.

## Visual differences

None.