### PR TITLE
Remove Ruby version from Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
-
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,8 +352,5 @@ DEPENDENCIES
   web-console
   webmock
 
-RUBY VERSION
-   ruby 2.6.5p114
-
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
It's better to have a single source of truth for Ruby version

This is part of the work to upgrade all apps to Ruby 2.7.1, but there were no other changes needed. 

I've left the Ruby version as 2.6.5 since there is an automatic script to change Ruby versions across govuk apps.